### PR TITLE
Fix memory leak by not removing GC callback created by gecko.

### DIFF
--- a/deps/spidershim/src/v8isolate.cc
+++ b/deps/spidershim/src/v8isolate.cc
@@ -245,7 +245,10 @@ void Isolate::Dispose() {
     MOZ_CRASH("Cannot dispose an Isolate that is entered by a thread");
   }
   Enter();
-  JS_SetGCCallback(pimpl_->cx, NULL, NULL);
+  // If the GC callback was created by gecko, don't null it out.
+  if (!pimpl_->chromeGlobal) {
+    JS_SetGCCallback(pimpl_->cx, NULL, NULL);
+  }
   for (auto frame : pimpl_->stackFrames) {
     delete frame;
   }


### PR DESCRIPTION
After unsuccessfully trying to use various memory leak tools, I ended up just removing startup code until the leak went away and then slowly added it back.